### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testJekyll.yaml
+++ b/.github/workflows/testJekyll.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test Jekyll site
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/vibalcam/vibalcam.github.io/security/code-scanning/1](https://github.com/vibalcam/vibalcam.github.io/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the minimum required privileges. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to check out the repository but not to make any changes. 

You should insert the following block after the `name:` declaration and before the `on:` block in `.github/workflows/testJekyll.yaml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
